### PR TITLE
Add GLB export options, DPVO fix, and Blender import script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,4 +47,6 @@ _env_*
 
 # Built web assets
 web/
+*.abc
+*.fbx
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,16 +1,50 @@
 """ComfyUI-MotionCapture: Motion capture from video for ComfyUI."""
 
-import os
 import sys
 import logging
-from pathlib import Path
+import pathlib
+import importlib.util
 
 log = logging.getLogger("motioncapture")
-
 log.info("loading...")
-from comfy_env import register_nodes
-log.info("calling register_nodes")
-NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS = register_nodes()
+
+# Preload bpy's bundled libsycl and libembree (with SYCL support) before any
+# other package (e.g. pymeshlab) can load a SYCL-less libembree4.so.4.
+try:
+    import importlib.util as _ilu
+    import ctypes as _ctypes
+    _bpy_spec = _ilu.find_spec("bpy")
+    if _bpy_spec is not None:
+        _bpy_lib_dir = pathlib.Path(_bpy_spec.origin).parent / "lib"
+        for _lib in ("libsycl.so.7", "libembree4.so.4"):
+            _lib_path = _bpy_lib_dir / _lib
+            if _lib_path.exists():
+                _ctypes.CDLL(str(_lib_path), mode=_ctypes.RTLD_GLOBAL)
+                log.info("Preloaded %s", _lib)
+except Exception as _e:
+    log.warning("bpy library preload failed (bpy may not work): %s", _e)
+
+_pkg_dir = pathlib.Path(__file__).parent
+_nodes_dir = _pkg_dir / "nodes"
+
+# Load MotionCapture's 'nodes' package under a unique name to avoid collision
+# with ComfyUI's top-level nodes.py (both would otherwise be named 'nodes').
+_mod_name = "ComfyUI_MotionCapture_nodes"
+if _mod_name not in sys.modules:
+    _spec = importlib.util.spec_from_file_location(
+        _mod_name,
+        _nodes_dir / "__init__.py",
+        submodule_search_locations=[str(_nodes_dir)],
+    )
+    _mod = importlib.util.module_from_spec(_spec)
+    _mod.__package__ = _mod_name
+    sys.modules[_mod_name] = _mod
+    _spec.loader.exec_module(_mod)
+else:
+    _mod = sys.modules[_mod_name]
+
+NODE_CLASS_MAPPINGS = _mod.NODE_CLASS_MAPPINGS
+NODE_DISPLAY_NAME_MAPPINGS = _mod.NODE_DISPLAY_NAME_MAPPINGS
 
 WEB_DIRECTORY = "./web"
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS", "WEB_DIRECTORY"]

--- a/nodes/__init__.py
+++ b/nodes/__init__.py
@@ -23,6 +23,7 @@ from .smpl_retarget_node import SMPLRetargetToSMPL
 from .smpl_to_mixamo_node import SMPLToMixamo
 from .rest_pose_node import ExtractRestPose
 from .glb_export_node import SMPLToGLB
+from .gvhmr_bundle_node import GVHMRBlenderBundle, GVHMRMayaBundle
 
 # Viewer nodes
 from .viewer_node import NODE_CLASS_MAPPINGS as viewer_mappings
@@ -53,6 +54,8 @@ NODE_CLASS_MAPPINGS = {
     "SMPLToMixamo": SMPLToMixamo,
     "ExtractRestPose": ExtractRestPose,
     "SMPLToGLB": SMPLToGLB,
+    "GVHMRBlenderBundle": GVHMRBlenderBundle,
+    "GVHMRMayaBundle": GVHMRMayaBundle,
     # Viewer nodes
     **viewer_mappings,
     **camera_viewer_mappings,
@@ -81,6 +84,8 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "SMPLToMixamo": "SMPL to Mixamo",
     "ExtractRestPose": "Extract Rest Pose",
     "SMPLToGLB": "SMPL to GLB Animation",
+    "GVHMRBlenderBundle": "GVHMR Bundle for Blender",
+    "GVHMRMayaBundle": "GVHMR Bundle for Maya",
     # Viewer nodes
     **viewer_display,
     **camera_viewer_display,

--- a/nodes/bvh_retarget_node.py
+++ b/nodes/bvh_retarget_node.py
@@ -429,7 +429,7 @@ class BVHtoFBX:
             if character_type == "auto":
                 character_type = "vrm" if character_path.suffix.lower() == ".vrm" else "fbx"
 
-            Log.info(f"[BVHtoFBX] Character type: {character_type}")
+            log.info(f"[BVHtoFBX] Character type: {character_type}")
 
             # Prepare output directory
             output_path = Path(output_path)

--- a/nodes/bvh_retarget_node.py
+++ b/nodes/bvh_retarget_node.py
@@ -69,6 +69,13 @@ VROID_BONE_MAP = {
     'RightToes': 'J_Bip_R_ToeBase',
 }
 
+COMMON_BONE_PREFIXES = (
+    "mixamorig:",
+    "mixamorig_",
+    "mixamo:",
+    "mixamo_",
+)
+
 
 # ===============================================================================
 # ISOLATED BLENDER WORKER
@@ -171,8 +178,21 @@ class BVHtoFBXWorker:
         log.debug("BVH Armature Bones: %s", [b.name for b in bvh_armature.data.bones])
 
         # Auto-detect bone naming convention
-        bone_names = char_armature.pose.bones.keys()
+        bone_names = list(char_armature.pose.bones.keys())
         is_vroid = any("J_Bip_C_Hips" in b for b in bone_names)
+
+        def resolve_target_bone(base_name):
+            if base_name in char_armature.pose.bones:
+                return base_name
+            for prefix in COMMON_BONE_PREFIXES:
+                candidate = f"{prefix}{base_name}"
+                if candidate in char_armature.pose.bones:
+                    return candidate
+            suffix = f":{base_name}"
+            for bone_name in bone_names:
+                if bone_name.endswith(suffix) or bone_name.endswith(f"_{base_name}"):
+                    return bone_name
+            return None
 
         bone_map = BONE_MAP.copy()
         if is_vroid:
@@ -184,6 +204,20 @@ class BVHtoFBXWorker:
                 else:
                     new_map[smpl] = vrm
             bone_map = new_map
+        else:
+            resolved_map = {}
+            missing_targets = []
+            for smpl, target in bone_map.items():
+                resolved = resolve_target_bone(target)
+                if resolved is None:
+                    missing_targets.append(target)
+                    resolved = target
+                resolved_map[smpl] = resolved
+            bone_map = resolved_map
+            if any("mixamorig:" in bone for bone in bone_map.values()):
+                log.info("Detected Mixamo 'mixamorig:' bone prefix")
+            elif any("mixamorig_" in bone for bone in bone_map.values()):
+                log.info("Detected Mixamo 'mixamorig_' bone prefix")
 
         # Set up bone mapping
         log.info("Setting up bone mapping...")
@@ -216,9 +250,13 @@ class BVHtoFBXWorker:
 
         bvh_height = get_skeleton_height(bvh_armature, 'Pelvis', 'Head')
         if is_vroid:
-            target_height = get_skeleton_height(char_armature, 'J_Bip_C_Hips', 'J_Bip_C_Head')
+            hips_bone = 'J_Bip_C_Hips'
+            head_bone = 'J_Bip_C_Head'
         else:
-            target_height = get_skeleton_height(char_armature, 'Hips', 'Head')
+            hips_bone = bone_map.get('Pelvis', 'Hips')
+            head_bone = bone_map.get('Head', 'Head')
+
+        target_height = get_skeleton_height(char_armature, hips_bone, head_bone)
 
         scale_ratio = target_height / bvh_height if bvh_height > 0.01 else 1.0
         log.info("Scale ratio: %.3f", scale_ratio)
@@ -275,12 +313,8 @@ class BVHtoFBXWorker:
         # Calculate foot height compensation
         bvh_l_foot = 'L_Ankle'
         bvh_r_foot = 'R_Ankle'
-        if is_vroid:
-            target_l_foot = 'J_Bip_L_Foot'
-            target_r_foot = 'J_Bip_R_Foot'
-        else:
-            target_l_foot = 'LeftFoot'
-            target_r_foot = 'RightFoot'
+        target_l_foot = bone_map.get('L_Ankle', 'J_Bip_L_Foot' if is_vroid else 'LeftFoot')
+        target_r_foot = bone_map.get('R_Ankle', 'J_Bip_R_Foot' if is_vroid else 'RightFoot')
 
         bvh_min_foot_z = float('inf')
         target_min_foot_z = float('inf')
@@ -304,7 +338,7 @@ class BVHtoFBXWorker:
                 target_min_foot_z = min(target_min_foot_z, target_r_z)
 
         foot_height_offset = target_min_foot_z - bvh_min_foot_z
-        if abs(foot_height_offset) > 0.05:
+        if bvh_min_foot_z != float('inf') and target_min_foot_z != float('inf') and abs(foot_height_offset) > 0.05:
             log.info("Applying height compensation: %.3fm", foot_height_offset)
             char_armature.location.z -= foot_height_offset
             bpy.context.view_layer.update()

--- a/nodes/glb_export_node.py
+++ b/nodes/glb_export_node.py
@@ -17,9 +17,31 @@ from .smpl_to_bvh_node import SMPL_21_JOINT_NAMES, SMPL_21_PARENTS
 
 logger = logging.getLogger("SMPLToGLB")
 
-# Number of body joints (excluding root pelvis for body_pose, including it for skeleton)
+# Number of body joints (excluding root pelvis for body_pose)
 NUM_BODY_JOINTS = 21
-NUM_JOINTS = 22  # 1 root + 21 body
+
+SMPLX_55_JOINT_NAMES = [
+    "pelvis",
+    "left_hip", "right_hip", "spine1",
+    "left_knee", "right_knee", "spine2",
+    "left_ankle", "right_ankle", "spine3",
+    "left_foot", "right_foot", "neck",
+    "left_collar", "right_collar", "head",
+    "left_shoulder", "right_shoulder",
+    "left_elbow", "right_elbow",
+    "left_wrist", "right_wrist",
+    "jaw", "left_eye_smplhf", "right_eye_smplhf",
+    "left_index1", "left_index2", "left_index3",
+    "left_middle1", "left_middle2", "left_middle3",
+    "left_pinky1", "left_pinky2", "left_pinky3",
+    "left_ring1", "left_ring2", "left_ring3",
+    "left_thumb1", "left_thumb2", "left_thumb3",
+    "right_index1", "right_index2", "right_index3",
+    "right_middle1", "right_middle2", "right_middle3",
+    "right_pinky1", "right_pinky2", "right_pinky3",
+    "right_ring1", "right_ring2", "right_ring3",
+    "right_thumb1", "right_thumb2", "right_thumb3",
+]
 
 
 def _compute_vertex_normals(vertices, faces):
@@ -44,7 +66,6 @@ def _collapse_smplx_weights_to_smpl22(weights_55, parents_55):
     Collapse SMPLX 55-joint weights to 22 SMPL body joints.
     Joints 22-54 (hands, face) are mapped to their nearest body ancestor.
     """
-    # Build collapse map: for each joint >= 22, find ancestor <= 21
     collapse_map = {}
     for j in range(22, 55):
         p = j
@@ -155,6 +176,18 @@ class SMPLToGLB:
                     "step": 1,
                     "tooltip": "Animation frames per second"
                 }),
+                "gender": (["neutral", "male", "female"], {
+                    "default": "neutral",
+                    "tooltip": "SMPLX body model gender (neutral / male / female)"
+                }),
+                "skeleton": (["smplx_55", "smpl_22"], {
+                    "default": "smplx_55",
+                    "tooltip": "smplx_55: full 55-joint rig with controllable fingers; smpl_22: compact 22-joint body rig"
+                }),
+                "hand_pose": (["halfway", "open", "closed"], {
+                    "default": "halfway",
+                    "tooltip": "Hand pose for the 55-joint rig. halfway = model mean (natural relaxed), open = template T-pose, closed = fist. Ignored for smpl_22."
+                }),
             },
         }
 
@@ -164,7 +197,7 @@ class SMPLToGLB:
     CATEGORY = "MotionCapture/GVHMR"
     OUTPUT_NODE = True
 
-    def export_glb(self, npz_path="", fps=30):
+    def export_glb(self, npz_path="", fps=30, gender="neutral", skeleton="smplx_55", hand_pose="halfway"):
         if not npz_path or not npz_path.strip():
             raise ValueError("npz_path is required")
         npz_file = Path(npz_path)
@@ -186,7 +219,8 @@ class SMPLToGLB:
         # ---- Load SMPLX model data ----
         data_dir = Path(__file__).parent / "body_model"
         models_dir = Path(folder_paths.models_dir) / "motion_capture" / "body_models" / "smplx"
-        smplx_path = models_dir / "SMPLX_NEUTRAL.npz"
+        smplx_filename = f"SMPLX_{gender.upper()}.npz"
+        smplx_path = models_dir / smplx_filename
         if not smplx_path.exists():
             raise FileNotFoundError(f"SMPLX model not found: {smplx_path}")
 
@@ -220,27 +254,62 @@ class SMPLToGLB:
 
         # ---- Skeleton ----
         J_all = J_regressor @ v_shaped_smplx  # (55, 3)
-        J = J_all[:NUM_JOINTS].astype(np.float64)  # (22, 3) -- body joints only
-
-        # ---- Skinning weights ----
         smpl_weights_55 = smplx2smpl @ lbs_weights  # (6890, 55)
-        weights_22 = _collapse_smplx_weights_to_smpl22(smpl_weights_55, parents_55)  # (6890, 22)
-        joint_indices, joint_weights = _top_k_weights(weights_22, k=4)
+
+        use_55 = (skeleton == "smplx_55")
+        num_joints = 55 if use_55 else 22
+
+        if use_55:
+            J = J_all.astype(np.float64)  # (55, 3)
+            joint_names = SMPLX_55_JOINT_NAMES
+            joint_parents = parents_55
+            lbs = smpl_weights_55  # (6890, 55)
+        else:
+            J = J_all[:22].astype(np.float64)  # (22, 3)
+            joint_names = SMPL_21_JOINT_NAMES
+            joint_parents = np.array(SMPL_21_PARENTS, dtype=np.int32)
+            lbs = _collapse_smplx_weights_to_smpl22(smpl_weights_55, parents_55)  # (6890, 22)
+
+        joint_indices, joint_weights = _top_k_weights(lbs, k=4)
 
         # ---- Inverse bind matrices ----
-        ibms = np.zeros((NUM_JOINTS, 4, 4), dtype=np.float32)
-        for j in range(NUM_JOINTS):
+        ibms = np.zeros((num_joints, 4, 4), dtype=np.float32)
+        for j in range(num_joints):
             ibms[j] = np.eye(4, dtype=np.float32)
             ibms[j, :3, 3] = -J[j].astype(np.float32)
 
         # ---- Animation data ----
-        # Combine global_orient + body_pose -> (F, 22, 3) axis-angle
-        full_pose = np.concatenate([
+        body_pose_22 = np.concatenate([
             global_orient.reshape(-1, 1, 3),
             body_pose.reshape(-1, NUM_BODY_JOINTS, 3)
         ], axis=1).astype(np.float64)  # (F, 22, 3)
 
-        quats = _axis_angle_to_quat(full_pose)  # (F, 22, 4) in (x,y,z,w)
+        if use_55:
+            # Joints 22-24: jaw + eyes (always zero)
+            # Joints 25-39: left hand (15 joints), joints 40-54: right hand (15 joints)
+            # hands_meanl/r from the model = natural relaxed pose ("halfway")
+            hands_meanl = np.asarray(smplx_data.get('hands_meanl', np.zeros(45)), dtype=np.float64)  # (45,)
+            hands_meanr = np.asarray(smplx_data.get('hands_meanr', np.zeros(45)), dtype=np.float64)  # (45,)
+
+            hand_aa = np.zeros((33, 3), dtype=np.float64)
+            if hand_pose == "halfway":
+                scale = 1.0
+            elif hand_pose == "closed":
+                scale = 2.0
+            else:  # "open"
+                scale = 0.0
+
+            if scale != 0.0:
+                # indices 3-17 = left hand (joints 25-39), indices 18-32 = right hand (joints 40-54)
+                hand_aa[3:18] = (hands_meanl * scale).reshape(15, 3)
+                hand_aa[18:33] = (hands_meanr * scale).reshape(15, 3)
+
+            hand_pose_rest = np.tile(hand_aa, (num_frames, 1, 1))  # (F, 33, 3)
+            full_pose = np.concatenate([body_pose_22, hand_pose_rest], axis=1)  # (F, 55, 3)
+        else:
+            full_pose = body_pose_22  # (F, 22, 3)
+
+        quats = _axis_angle_to_quat(full_pose)  # (F, num_joints, 4) in (x,y,z,w)
         timestamps = (np.arange(num_frames, dtype=np.float32) / fps)
         # Root translation = skeleton root position + transl offset
         # In SMPL, transl is added on top of FK output: verts = LBS(...) + transl
@@ -327,7 +396,7 @@ class SMPLToGLB:
         ibms_col = np.transpose(ibms, (0, 2, 1)).astype(np.float32)  # to column-major
         ibm_data = ibms_col.tobytes()
         ibm_bv = add_buffer_view(ibm_data)
-        ibm_acc = add_accessor(ibm_bv, CT_FLOAT, NUM_JOINTS, "MAT4")
+        ibm_acc = add_accessor(ibm_bv, CT_FLOAT, num_joints, "MAT4")
 
         # 7. Animation timestamps
         ts_data = timestamps.tobytes()
@@ -342,7 +411,7 @@ class SMPLToGLB:
 
         # 9. Per-joint rotation quaternions
         rot_accs = []
-        for j in range(NUM_JOINTS):
+        for j in range(num_joints):
             q = quats[:, j, :].astype(np.float32).copy()  # (F, 4)
             q_data = q.tobytes()
             q_bv = add_buffer_view(q_data)
@@ -350,14 +419,14 @@ class SMPLToGLB:
             rot_accs.append(q_acc)
 
         # ---- Build glTF JSON ----
-        # Nodes: 0 = armature root, 1..22 = joint nodes, 23 = mesh node
+        # Nodes: 0 = armature root, 1..N = joint nodes, N+1 = mesh node
         # Joint nodes are arranged so node index = joint_index + 1
         # (node 0 is the armature container)
 
         nodes = []
 
         # Node 0: Armature root (contains skeleton + mesh)
-        armature_children = [NUM_JOINTS + 1]  # mesh node
+        armature_children = [num_joints + 1]  # mesh node
         # Find root joints (pelvis = joint 0 -> node 1)
         armature_children.append(1)
         nodes.append({
@@ -365,28 +434,28 @@ class SMPLToGLB:
             "children": armature_children,
         })
 
-        # Nodes 1..22: Joint nodes
-        for j in range(NUM_JOINTS):
-            node = {"name": SMPL_21_JOINT_NAMES[j]}
+        # Nodes 1..N: Joint nodes
+        for j in range(num_joints):
+            node = {"name": joint_names[j]}
             # Translation = offset from parent (or absolute for root)
-            if SMPL_21_PARENTS[j] == -1:
+            pj = int(joint_parents[j])
+            if pj == -1:
                 node["translation"] = J[j].tolist()
             else:
-                parent_j = SMPL_21_PARENTS[j]
-                offset = (J[j] - J[parent_j]).tolist()
+                offset = (J[j] - J[pj]).tolist()
                 node["translation"] = offset
 
             # Find children of this joint
             children = []
-            for c in range(NUM_JOINTS):
-                if SMPL_21_PARENTS[c] == j:
+            for c in range(num_joints):
+                if int(joint_parents[c]) == j:
                     children.append(c + 1)  # node index = joint index + 1
             if children:
                 node["children"] = children
 
             nodes.append(node)
 
-        # Node 23: Mesh node
+        # Node 56: Mesh node
         nodes.append({
             "name": "SMPLMesh",
             "mesh": 0,
@@ -394,7 +463,7 @@ class SMPLToGLB:
         })
 
         # Skin
-        joint_node_indices = list(range(1, NUM_JOINTS + 1))
+        joint_node_indices = list(range(1, num_joints + 1))
         skin = {
             "inverseBindMatrices": ibm_acc,
             "joints": joint_node_indices,
@@ -437,7 +506,7 @@ class SMPLToGLB:
         })
 
         # Per-joint rotation samplers + channels
-        for j in range(NUM_JOINTS):
+        for j in range(num_joints):
             sampler_idx = len(samplers)
             samplers.append({
                 "input": ts_acc,
@@ -483,7 +552,7 @@ class SMPLToGLB:
 
         size_mb = glb_path.stat().st_size / (1024 * 1024)
         logger.info(f"[SMPLToGLB] Wrote {glb_filename} ({size_mb:.1f} MB) -- "
-                     f"{num_frames} frames, {NUM_JOINTS} joints, "
+                     f"{num_frames} frames, {num_joints} joints ({skeleton}), "
                      f"{len(positions)} vertices, {len(faces)} faces")
 
         return {"ui": {}, "result": (str(glb_path),)}

--- a/nodes/gvhmr_bundle_node.py
+++ b/nodes/gvhmr_bundle_node.py
@@ -1,0 +1,598 @@
+"""
+GVHMRBundle Node - collect ComfyUI-MotionCapture outputs into one folder.
+"""
+
+import json
+import shutil
+import struct
+from datetime import datetime
+from pathlib import Path
+from typing import Dict
+
+import folder_paths
+import numpy as np
+import scipy.sparse as sp
+from scipy.spatial.transform import Rotation as R
+
+from .glb_export_node import NUM_BODY_JOINTS, SMPLX_55_JOINT_NAMES, _top_k_weights
+from .shared_utils import next_sequential_filename
+
+
+def _clean_optional_path(value):
+    if value is None:
+        return ""
+    value = str(value).strip()
+    return "" if value.lower() in {"none", "null"} else value
+
+
+def _resolve_path(path_value):
+    path_value = _clean_optional_path(path_value)
+    if not path_value:
+        return None
+
+    path = Path(path_value).expanduser()
+    if path.exists():
+        return path.resolve()
+
+    output_candidate = Path(folder_paths.get_output_directory()) / path_value
+    if output_candidate.exists():
+        return output_candidate.resolve()
+
+    input_candidate = Path(folder_paths.get_input_directory()) / path_value
+    if input_candidate.exists():
+        return input_candidate.resolve()
+
+    return None
+
+
+def _copy_file(src_path, bundle_dir, used_names):
+    suffix = src_path.suffix
+    stem = src_path.stem
+    dst_name = src_path.name
+    index = 1
+    while dst_name in used_names:
+        dst_name = f"{stem}_{index:03d}{suffix}"
+        index += 1
+
+    dst_path = bundle_dir / dst_name
+    shutil.copy2(src_path, dst_path)
+    used_names.add(dst_name)
+    return dst_path
+
+
+def _default_smplx_model_path():
+    models_dir = Path(folder_paths.models_dir) / "motion_capture" / "body_models" / "smplx"
+    neutral = models_dir / "SMPLX_NEUTRAL.npz"
+    return neutral.resolve() if neutral.exists() else None
+
+
+def _extract_camera_from_npz(src):
+    if "R_cam2world" in src and "t_cam2world" in src and "K_fullimg" in src:
+        return (
+            src["R_cam2world"].astype(np.float64),
+            src["t_cam2world"].astype(np.float64),
+            src["K_fullimg"].astype(np.float64),
+        )
+    if "R_w2c" in src and "t_w2c" in src and "K_fullimg" in src:
+        r_w2c = src["R_w2c"].astype(np.float64)
+        t_w2c = src["t_w2c"].astype(np.float64)
+        r_c2w = r_w2c.transpose(0, 2, 1)
+        t_c2w = -np.einsum("fij,fj->fi", r_c2w, t_w2c)
+        return r_c2w, t_c2w, src["K_fullimg"].astype(np.float64)
+    return None, None, None
+
+
+def _load_camera_from_smpc_bin(bin_path):
+    with open(bin_path, "rb") as f:
+        magic = f.read(4)
+        if magic != b"SMPC":
+            raise ValueError(f"Not an SMPC file: {bin_path}")
+        num_frames = struct.unpack("<I", f.read(4))[0]
+        num_verts = struct.unpack("<I", f.read(4))[0]
+        num_faces = struct.unpack("<I", f.read(4))[0]
+        fps = struct.unpack("<f", f.read(4))[0]
+        f.read(64)
+        has_camera = struct.unpack("<I", f.read(4))[0]
+        img_w = struct.unpack("<I", f.read(4))[0]
+        img_h = struct.unpack("<I", f.read(4))[0]
+        f.read(num_frames * num_verts * 3 * 4)
+        f.read(num_faces * 3 * 4)
+        if not has_camera:
+            return None, None, None, img_w, img_h, fps
+        r = np.frombuffer(f.read(num_frames * 9 * 4), dtype=np.float32).reshape(num_frames, 3, 3).astype(np.float64)
+        t = np.frombuffer(f.read(num_frames * 3 * 4), dtype=np.float32).reshape(num_frames, 3).astype(np.float64)
+        k = np.frombuffer(f.read(num_frames * 9 * 4), dtype=np.float32).reshape(num_frames, 3, 3).astype(np.float64)
+    return r, t, k, img_w, img_h, fps
+
+
+def _load_camera_for_maya(source_paths, fallback_fps):
+    img_w, img_h = 1920, 1080
+    camera_fps = fallback_fps
+
+    if source_paths.get("smpc_bin") is not None:
+        r, t, k, img_w, img_h, smpc_fps = _load_camera_from_smpc_bin(source_paths["smpc_bin"])
+        if r is not None:
+            return r, t, k, img_w, img_h, smpc_fps or camera_fps, "smpc_bin"
+
+    for key in ("camera_npz", "npz"):
+        src = source_paths.get(key)
+        if src is None:
+            continue
+        data = np.load(str(src))
+        r, t, k = _extract_camera_from_npz(data)
+        if r is None:
+            continue
+        if "img_width" in data:
+            img_w = int(data["img_width"].flat[0])
+        if "img_height" in data:
+            img_h = int(data["img_height"].flat[0])
+        return r, t, k, img_w, img_h, camera_fps, key
+
+    return None, None, None, img_w, img_h, camera_fps, ""
+
+
+def _write_maya_camera_json(bundle_dir, source_paths, fps):
+    r_c2w, t_c2w, k_fullimg, img_w, img_h, camera_fps, source = _load_camera_for_maya(source_paths, fps)
+    if r_c2w is None:
+        return None
+
+    frames = []
+    sensor_width_mm = 36.0
+    for idx in range(r_c2w.shape[0]):
+        r = r_c2w[idx]
+        t = t_c2w[idx]
+        matrix = [
+            float(r[0, 0]), float(r[0, 1]), float(r[0, 2]), 0.0,
+            float(r[1, 0]), float(r[1, 1]), float(r[1, 2]), 0.0,
+            float(r[2, 0]), float(r[2, 1]), float(r[2, 2]), 0.0,
+            float(t[0]), float(t[1]), float(t[2]), 1.0,
+        ]
+        focal_length_mm = None
+        if k_fullimg is not None and img_w > 0:
+            focal_length_mm = float(k_fullimg[idx][0, 0]) * sensor_width_mm / img_w
+        frames.append({
+            "frame": idx + 1,
+            "matrix": matrix,
+            "focal_length_mm": focal_length_mm,
+        })
+
+    camera_json = {
+        "schema": "comfyui-motioncapture.maya-camera",
+        "schema_version": 1,
+        "source": source,
+        "fps": float(camera_fps),
+        "img_width": int(img_w),
+        "img_height": int(img_h),
+        "sensor_width_mm": sensor_width_mm,
+        "camera_name": "GVHMR_Camera",
+        "coordinate_system": "maya_y_up_camera_minus_z_forward",
+        "frames": frames,
+    }
+
+    camera_path = bundle_dir / "camera_maya.json"
+    with open(camera_path, "w", encoding="utf-8") as f:
+        json.dump(camera_json, f, indent=2)
+        f.write("\n")
+    return camera_path
+
+
+def _write_maya_smplx_rig_json(bundle_dir, npz_path, fps, gender="neutral", hand_pose="halfway"):
+    data = np.load(str(npz_path))
+    body_pose = data["body_pose"]
+    global_orient = data["global_orient"]
+    betas = data["betas"]
+    transl = data.get("transl", None)
+    if transl is None:
+        transl = np.zeros((body_pose.shape[0], 3), dtype=np.float32)
+
+    num_frames = int(body_pose.shape[0])
+    data_dir = Path(__file__).parent / "body_model"
+    models_dir = Path(folder_paths.models_dir) / "motion_capture" / "body_models" / "smplx"
+    smplx_path = models_dir / f"SMPLX_{gender.upper()}.npz"
+    if not smplx_path.exists():
+        raise FileNotFoundError(f"SMPLX model not found: {smplx_path}")
+
+    smplx_data = np.load(str(smplx_path), allow_pickle=True)
+    v_template = smplx_data["v_template"].astype(np.float64)
+    shapedirs = smplx_data["shapedirs"][:, :, :10].astype(np.float64)
+    j_regressor = smplx_data["J_regressor"]
+    lbs_weights = smplx_data["weights"].astype(np.float64)
+    parents_55 = smplx_data["kintree_table"][0].astype(np.int32)
+    parents_55[0] = -1
+
+    if isinstance(j_regressor, np.ndarray) and j_regressor.ndim == 0:
+        j_regressor = j_regressor.item()
+    if hasattr(j_regressor, "toarray"):
+        j_regressor = j_regressor.toarray()
+    j_regressor = np.asarray(j_regressor, dtype=np.float64)
+
+    smplx2smpl = sp.load_npz(str(data_dir / "smplx2smpl_sparse.npz")).toarray().astype(np.float64)
+    faces = np.load(str(data_dir / "smpl_faces.npy")).astype(np.int32)
+
+    beta0 = betas[0].astype(np.float64)
+    v_shaped_smplx = v_template + np.einsum("vck,k->vc", shapedirs, beta0)
+    mesh_positions = (smplx2smpl @ v_shaped_smplx).astype(np.float32)
+
+    joints = (j_regressor @ v_shaped_smplx).astype(np.float32)
+    smpl_weights_55 = smplx2smpl @ lbs_weights
+    skin_indices, skin_weights = _top_k_weights(smpl_weights_55, k=4)
+
+    body_pose_22 = np.concatenate([
+        global_orient.reshape(-1, 1, 3),
+        body_pose.reshape(-1, NUM_BODY_JOINTS, 3),
+    ], axis=1).astype(np.float64)
+
+    hands_meanl = np.asarray(smplx_data.get("hands_meanl", np.zeros(45)), dtype=np.float64)
+    hands_meanr = np.asarray(smplx_data.get("hands_meanr", np.zeros(45)), dtype=np.float64)
+    hand_aa = np.zeros((33, 3), dtype=np.float64)
+    if hand_pose == "halfway":
+        hand_scale = 1.0
+    elif hand_pose == "closed":
+        hand_scale = 2.0
+    else:
+        hand_scale = 0.0
+    if hand_scale != 0.0:
+        hand_aa[3:18] = (hands_meanl * hand_scale).reshape(15, 3)
+        hand_aa[18:33] = (hands_meanr * hand_scale).reshape(15, 3)
+
+    hand_pose_rest = np.tile(hand_aa, (num_frames, 1, 1))
+    full_pose = np.concatenate([body_pose_22, hand_pose_rest], axis=1)
+    eulers_xyz = R.from_rotvec(full_pose.reshape(-1, 3)).as_euler("xyz", degrees=True).reshape(num_frames, 55, 3)
+    translations = (transl + joints[0]).astype(np.float32)
+
+    rig_json = {
+        "schema": "comfyui-motioncapture.maya-smplx-rig",
+        "schema_version": 1,
+        "source": str(npz_path),
+        "fps": float(fps),
+        "gender": gender,
+        "hand_pose": hand_pose,
+        "joint_names": SMPLX_55_JOINT_NAMES,
+        "joint_parents": parents_55.astype(int).tolist(),
+        "joint_positions": joints.astype(float).tolist(),
+        "mesh_positions": mesh_positions.astype(float).tolist(),
+        "faces": faces.astype(int).tolist(),
+        "skin_indices": skin_indices.astype(int).tolist(),
+        "skin_weights": skin_weights.astype(float).tolist(),
+        "animation": {
+            "root_translations": translations.astype(float).tolist(),
+            "joint_eulers_xyz_deg": eulers_xyz.astype(np.float32).astype(float).tolist(),
+        },
+    }
+
+    rig_path = bundle_dir / "smplx_rig_maya.json"
+    with open(rig_path, "w", encoding="utf-8") as f:
+        json.dump(rig_json, f, separators=(",", ":"))
+        f.write("\n")
+    return rig_path
+
+
+def _make_bundle_dir(bundle_name):
+    output_dir = Path(folder_paths.get_output_directory())
+    safe_prefix = "".join(ch if ch.isalnum() or ch in "-_" else "_" for ch in bundle_name.strip())
+    if not safe_prefix:
+        safe_prefix = "gvhmr_bundle"
+
+    bundle_folder_name = next_sequential_filename(output_dir, safe_prefix, "")
+    bundle_dir = output_dir / bundle_folder_name
+    bundle_dir.mkdir(parents=True, exist_ok=False)
+    return bundle_dir
+
+
+def _add_files_to_bundle(source_paths, bundle_dir, copy_files):
+    files: Dict[str, str] = {}
+    absolute_sources: Dict[str, str] = {}
+    used_names = set()
+
+    for key, src in source_paths.items():
+        if src is None:
+            continue
+        absolute_sources[key] = str(src)
+        if copy_files:
+            dst = _copy_file(src, bundle_dir, used_names)
+            files[key] = dst.name
+        else:
+            files[key] = str(src)
+
+    return files, absolute_sources
+
+
+def _write_manifest(bundle_dir, manifest):
+    manifest_path = bundle_dir / "manifest.json"
+    with open(manifest_path, "w", encoding="utf-8") as f:
+        json.dump(manifest, f, indent=2)
+        f.write("\n")
+    return manifest_path
+
+
+class GVHMRBlenderBundle:
+    """
+    Create a Blender-focused bundle for the GVHMR Blender add-on.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "npz_path": ("STRING", {
+                    "default": "",
+                    "multiline": False,
+                    "tooltip": "SMPL params .npz from GVHMR Inference or Save SMPL Motion",
+                }),
+                "bundle_name": ("STRING", {
+                    "default": "gvhmr_blender",
+                    "multiline": False,
+                    "tooltip": "Folder name prefix inside the ComfyUI output folder",
+                }),
+            },
+            "optional": {
+                "camera_npz_path": ("STRING", {
+                    "default": "",
+                    "multiline": False,
+                    "tooltip": "Camera trajectory .npz from GVHMR Inference",
+                }),
+                "smpc_bin_path": ("STRING", {
+                    "default": "",
+                    "multiline": False,
+                    "tooltip": "SMPC .bin from SMPL Viewer with Camera. This is preferred for Blender camera import.",
+                }),
+                "glb_path": ("STRING", {
+                    "default": "",
+                    "multiline": False,
+                    "tooltip": "Animated GLB from SMPL to GLB Animation",
+                }),
+                "fbx_path": ("STRING", {
+                    "default": "",
+                    "multiline": False,
+                    "tooltip": "Animated FBX from a retarget/export node",
+                }),
+                "bvh_path": ("STRING", {
+                    "default": "",
+                    "multiline": False,
+                    "tooltip": "Optional BVH motion file",
+                }),
+                "fps": ("INT", {
+                    "default": 24,
+                    "min": 1,
+                    "max": 240,
+                    "step": 1,
+                }),
+                "copy_files": ("BOOLEAN", {
+                    "default": True,
+                    "tooltip": "Copy all referenced files into the bundle folder. Disable to write references only.",
+                }),
+            },
+        }
+
+    RETURN_TYPES = ("STRING", "STRING", "STRING")
+    RETURN_NAMES = ("bundle_dir", "manifest_path", "info")
+    FUNCTION = "create_blender_bundle"
+    OUTPUT_NODE = True
+    CATEGORY = "MotionCapture/GVHMR"
+
+    def create_blender_bundle(
+        self,
+        npz_path: str,
+        bundle_name: str = "gvhmr_blender",
+        camera_npz_path: str = "",
+        smpc_bin_path: str = "",
+        glb_path: str = "",
+        fbx_path: str = "",
+        bvh_path: str = "",
+        fps: int = 24,
+        copy_files: bool = True,
+    ):
+        bundle_dir = _make_bundle_dir(bundle_name)
+        source_paths = {
+            "npz": _resolve_path(npz_path),
+            "camera_npz": _resolve_path(camera_npz_path),
+            "smpc_bin": _resolve_path(smpc_bin_path),
+            "glb": _resolve_path(glb_path),
+            "fbx": _resolve_path(fbx_path),
+            "bvh": _resolve_path(bvh_path),
+        }
+
+        if source_paths["npz"] is None:
+            raise FileNotFoundError(f"SMPL NPZ file not found: {npz_path}")
+
+        files, absolute_sources = _add_files_to_bundle(source_paths, bundle_dir, copy_files)
+
+        smplx_model = _default_smplx_model_path()
+        if smplx_model is not None:
+            files["smplx_model"] = str(smplx_model)
+
+        manifest = {
+            "schema": "comfyui-motioncapture.gvhmr-blender-bundle",
+            "schema_version": 1,
+            "created_at": datetime.now().isoformat(timespec="seconds"),
+            "generator": "ComfyUI-MotionCapture GVHMRBlenderBundle",
+            "files": files,
+            "absolute_sources": absolute_sources,
+            "scene": {
+                "fps": int(fps),
+                "sensor_width_mm": 36.0,
+                "flip_camera_y": True,
+                "camera_name": "GVHMR_Camera",
+            },
+            "notes": {
+                "camera_priority": "smpc_bin, then camera_npz, then npz embedded camera",
+                "body_priority": "fbx, then glb, with optional bvh",
+            },
+        }
+
+        manifest_path = _write_manifest(bundle_dir, manifest)
+
+        copied_count = len([key for key in files if key != "smplx_model"])
+        info = (
+            "GVHMR Blender Bundle Complete\n"
+            f"Bundle: {bundle_dir}\n"
+            f"Manifest: {manifest_path}\n"
+            f"Files {'copied' if copy_files else 'referenced'}: {copied_count}\n"
+            "Blender: select this bundle folder in the GVHMR add-on.\n"
+        )
+
+        return (str(bundle_dir), str(manifest_path), info)
+
+
+class GVHMRMayaBundle:
+    """
+    Create a Maya-focused bundle with an FBX/Alembic body and camera_maya.json.
+    """
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "bundle_name": ("STRING", {
+                    "default": "gvhmr_maya",
+                    "multiline": False,
+                    "tooltip": "Folder name prefix inside the ComfyUI output folder",
+                }),
+            },
+            "optional": {
+                "camera_npz_path": ("STRING", {
+                    "default": "",
+                    "multiline": False,
+                    "tooltip": "Camera trajectory .npz from GVHMR Inference.",
+                }),
+                "smpc_bin_path": ("STRING", {
+                    "default": "",
+                    "multiline": False,
+                    "tooltip": "SMPC .bin from SMPL Viewer with Camera.",
+                }),
+                "npz_path": ("STRING", {
+                    "default": "",
+                    "multiline": False,
+                    "tooltip": "SMPL params .npz. Used to generate a Maya SMPLX-55 skeletal rig, and as camera fallback if it embeds camera data.",
+                }),
+                "gender": (["neutral", "male", "female"], {
+                    "default": "neutral",
+                    "tooltip": "SMPLX body model gender used for the optional Maya skeletal rig.",
+                }),
+                "hand_pose": (["halfway", "open", "closed"], {
+                    "default": "halfway",
+                    "tooltip": "Default finger pose for the optional Maya SMPLX-55 rig.",
+                }),
+                "fps": ("INT", {
+                    "default": 24,
+                    "min": 1,
+                    "max": 240,
+                    "step": 1,
+                }),
+                "copy_files": ("BOOLEAN", {
+                    "default": True,
+                    "tooltip": "Copy all referenced files into the bundle folder. Disable to write references only.",
+                }),
+                "camera_only": ("BOOLEAN", {
+                    "default": False,
+                    "tooltip": "Allow a Maya bundle with only the animated camera and no FBX/Alembic body.",
+                }),
+                "allow_smpc_mesh": ("BOOLEAN", {
+                    "default": True,
+                    "tooltip": "Allow SMPC .bin as a Maya diagnostic animated mesh cache when no FBX/Alembic body is provided.",
+                }),
+            },
+        }
+
+    RETURN_TYPES = ("STRING", "STRING", "STRING")
+    RETURN_NAMES = ("bundle_dir", "manifest_path", "info")
+    FUNCTION = "create_maya_bundle"
+    OUTPUT_NODE = True
+    CATEGORY = "MotionCapture/GVHMR"
+
+    def create_maya_bundle(
+        self,
+        bundle_name: str = "gvhmr_maya",
+        fbx_path: str = "",
+        alembic_path: str = "",
+        camera_npz_path: str = "",
+        smpc_bin_path: str = "",
+        npz_path: str = "",
+        gender: str = "neutral",
+        hand_pose: str = "halfway",
+        fps: int = 24,
+        copy_files: bool = True,
+        camera_only: bool = False,
+        allow_smpc_mesh: bool = True,
+    ):
+        bundle_dir = _make_bundle_dir(bundle_name)
+        source_paths = {
+            "camera_npz": _resolve_path(camera_npz_path),
+            "smpc_bin": _resolve_path(smpc_bin_path),
+            "npz": _resolve_path(npz_path),
+        }
+
+        has_smpc_mesh = source_paths["smpc_bin"] is not None and allow_smpc_mesh
+        has_smplx_rig = source_paths["npz"] is not None
+        if not has_smpc_mesh and not has_smplx_rig and not camera_only:
+            raise FileNotFoundError(
+                "Maya bundle needs an SMPL NPZ for the SMPLX rig, or an SMPC mesh cache for diagnostics. "
+                "Enable camera_only to export only the camera."
+            )
+
+        maya_camera_path = _write_maya_camera_json(bundle_dir, source_paths, fps)
+        if maya_camera_path is None:
+            raise FileNotFoundError("No camera data found. Provide smpc_bin_path, camera_npz_path, or NPZ with embedded camera data.")
+
+        files, absolute_sources = _add_files_to_bundle(source_paths, bundle_dir, copy_files)
+        files["maya_camera_json"] = maya_camera_path.name
+        maya_smplx_rig_path = None
+        if has_smplx_rig:
+            maya_smplx_rig_path = _write_maya_smplx_rig_json(
+                bundle_dir,
+                source_paths["npz"],
+                fps,
+                gender=gender,
+                hand_pose=hand_pose,
+            )
+            files["maya_smplx_rig_json"] = maya_smplx_rig_path.name
+
+        manifest = {
+            "schema": "comfyui-motioncapture.gvhmr-maya-bundle",
+            "schema_version": 1,
+            "created_at": datetime.now().isoformat(timespec="seconds"),
+            "generator": "ComfyUI-MotionCapture GVHMRMayaBundle",
+            "files": files,
+            "absolute_sources": absolute_sources,
+            "scene": {
+                "fps": int(fps),
+                "camera_name": "GVHMR_Camera",
+                "smplx_rig_name": "GVHMR_SMPLX",
+            },
+            "notes": {
+                "body_priority": "maya_smplx_rig_json, then diagnostic smpc mesh cache. GLB, FBX, and Alembic are intentionally not included for this Maya path.",
+                "camera": "Maya importer reads maya_camera_json directly and does not need NumPy.",
+                "maya_smplx_rig_json": "Experimental SMPLX-55 skeletal rig payload generated from the SMPL NPZ.",
+            },
+        }
+
+        manifest_path = _write_manifest(bundle_dir, manifest)
+
+        body_kind = (
+            "SMPLX skeletal rig"
+            if has_smplx_rig
+            else "SMPC mesh cache"
+            if has_smpc_mesh
+            else "camera only"
+        )
+        info = (
+            "GVHMR Maya Bundle Complete\n"
+            f"Bundle: {bundle_dir}\n"
+            f"Manifest: {manifest_path}\n"
+            f"Body: {body_kind}\n"
+            f"SMPLX Rig: {'yes' if maya_smplx_rig_path is not None else 'no'}\n"
+            "Maya: select this bundle folder in the GVHMR importer.\n"
+        )
+
+        return (str(bundle_dir), str(manifest_path), info)
+
+
+NODE_CLASS_MAPPINGS = {
+    "GVHMRBlenderBundle": GVHMRBlenderBundle,
+    "GVHMRMayaBundle": GVHMRMayaBundle,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "GVHMRBlenderBundle": "GVHMR Bundle for Blender",
+    "GVHMRMayaBundle": "GVHMR Bundle for Maya",
+}

--- a/nodes/inference_node.py
+++ b/nodes/inference_node.py
@@ -181,11 +181,12 @@ def _run_dpvo(images_np: np.ndarray, intrinsics: torch.Tensor, dpvo_dir: str = "
     slam = DPVO(cfg, checkpoint_path, ht=height, wd=width, viz=False)
 
     # Process frames
+    intrinsics_tensor = torch.tensor([fx, fy, cx, cy], dtype=torch.float32).cuda()
     for i, frame in enumerate(tqdm(images_np, desc="DPVO")):
-        # DPVO expects BGR
+        # DPVO expects a torch tensor [C, H, W] uint8 on CUDA in BGR order
         frame_bgr = cv2.cvtColor(frame, cv2.COLOR_RGB2BGR)
-        intrinsics_arr = np.array([fx, fy, cx, cy])
-        slam(i, frame_bgr, intrinsics_arr)
+        frame_tensor = torch.from_numpy(frame_bgr).permute(2, 0, 1).cuda()
+        slam(i, frame_tensor, intrinsics_tensor)
 
     # Get trajectory
     # DPVO outputs poses as (N, 7): [tx, ty, tz, qx, qy, qz, qw]

--- a/nodes/smpl_camera_viewer_node.py
+++ b/nodes/smpl_camera_viewer_node.py
@@ -41,6 +41,13 @@ class SMPLCameraViewer:
                     "default": "#4a9eff",
                     "tooltip": "Hex color for the mesh (e.g. #4a9eff for blue)"
                 }),
+                "fps": ("INT", {
+                    "default": 24,
+                    "min": 1,
+                    "max": 240,
+                    "step": 1,
+                    "tooltip": "Frame rate written into the SMPC camera/mesh file"
+                }),
                 "video": ("VIDEO", {
                     "tooltip": "Reference video to display side-by-side with the 3D mesh"
                 }),
@@ -53,7 +60,7 @@ class SMPLCameraViewer:
     CATEGORY = "MotionCapture/GVHMR"
     OUTPUT_NODE = True
 
-    def create_viewer_data(self, npz_path="", camera_npz_path="", mesh_color="#4a9eff", video=None):
+    def create_viewer_data(self, npz_path="", camera_npz_path="", mesh_color="#4a9eff", fps=24, video=None):
         logger.info("[SMPLCameraViewer] Generating 3D mesh + camera data...")
 
         if not npz_path or not npz_path.strip():
@@ -243,7 +250,7 @@ class SMPLCameraViewer:
         faces_u32 = faces.astype(np.uint32)
         num_output_frames = vertices_array.shape[0]
         num_verts = vertices_array.shape[1]
-        fps = 30
+        fps = max(1, int(fps))
 
         logger.info(f"[SMPLCameraViewer] Generated mesh: {num_output_frames} frames, "
                      f"{num_verts} vertices, {faces_u32.shape[0]} faces")

--- a/scripts/blender_export_maya.py
+++ b/scripts/blender_export_maya.py
@@ -1,0 +1,394 @@
+"""
+GVHMR → Maya Export Script
+===========================
+Exports the current Blender scene to Alembic (.abc) and/or FBX (.fbx) for use in Maya.
+
+This version is specifically designed to improve Maya FBX compatibility by:
+- duplicating the export objects into a temporary collection,
+- baking evaluated source armature pose onto the duplicate armature,
+- exporting selection only,
+- exporting only one baked action per armature.
+
+Usage
+-----
+1. First run your Blender import script so the scene contains:
+   - animated armature
+   - skinned mesh
+   - animated camera
+2. Edit the CONFIGURE section below.
+3. Run this script from Blender's Scripting workspace.
+"""
+
+import bpy
+from pathlib import Path
+
+
+# ── CONFIGURE ────────────────────────────────────────────────────────────────
+
+OUTPUT_DIR = "/home/innovation/dev-lbringer/ComfyUI_nightly/custom_nodes/ComfyUI-MotionCapture/maya_files"
+EXPORT_NAME = "karoshi_mocap"
+
+EXPORT_ALEMBIC = True
+EXPORT_FBX = True
+
+# Set to 0 to keep current Blender scene render resolution
+RESOLUTION_X = 0
+RESOLUTION_Y = 0
+
+TEMP_EXPORT_COLLECTION = "_TEMP_MAYA_EXPORT"
+
+# ── END CONFIGURE ────────────────────────────────────────────────────────────
+
+
+def print_header(msg):
+    print(f"\n=== {msg} ===")
+
+
+def remove_collection_and_contents(col):
+    if col is None:
+        return
+
+    for obj in list(col.objects):
+        bpy.data.objects.remove(obj, do_unlink=True)
+
+    bpy.data.collections.remove(col)
+
+
+def duplicate_for_export(objects, collection_name):
+    old = bpy.data.collections.get(collection_name)
+    if old is not None:
+        remove_collection_and_contents(old)
+
+    temp_col = bpy.data.collections.new(collection_name)
+    bpy.context.scene.collection.children.link(temp_col)
+
+    obj_map = {}
+
+    # Duplicate objects and their data
+    for obj in objects:
+        obj_copy = obj.copy()
+        if obj.data is not None:
+            obj_copy.data = obj.data.copy()
+        temp_col.objects.link(obj_copy)
+        obj_map[obj] = obj_copy
+
+    # Rebuild parenting if parent is also in the duplicated set
+    for src, dst in obj_map.items():
+        if src.parent in obj_map:
+            dst.parent = obj_map[src.parent]
+            dst.parent_type = src.parent_type
+            dst.parent_bone = src.parent_bone
+            dst.matrix_parent_inverse = src.matrix_parent_inverse.copy()
+
+    # IMPORTANT: retarget mesh armature modifiers to duplicated armatures
+    for src, dst in obj_map.items():
+        if dst.type != 'MESH':
+            continue
+
+        for mod in dst.modifiers:
+            if mod.type == 'ARMATURE' and getattr(mod, "object", None) is not None:
+                src_target = mod.object
+                if src_target in obj_map and obj_map[src_target].type == 'ARMATURE':
+                    mod.object = obj_map[src_target]
+
+        # Also fix direct armature parenting if needed
+        if dst.parent and dst.parent.type == 'ARMATURE':
+            # already remapped above if parent was in obj_map
+            pass
+
+    return temp_col, obj_map
+
+
+def clear_animation_data_recursive(obj):
+    if obj.animation_data:
+        obj.animation_data_clear()
+
+    if obj.data and hasattr(obj.data, "animation_data") and obj.data.animation_data:
+        obj.data.animation_data_clear()
+
+
+def find_export_objects():
+    cameras = [o for o in bpy.data.objects if o.type == 'CAMERA' and o.visible_get()]
+    armatures = [o for o in bpy.data.objects if o.type == 'ARMATURE' and o.visible_get()]
+    meshes = [o for o in bpy.data.objects if o.type == 'MESH' and o.visible_get()]
+    return cameras, armatures, meshes
+
+
+def ensure_animation_data(obj):
+    if obj.animation_data is None:
+        obj.animation_data_create()
+
+
+def bake_armature_evaluated_pose(scene, src_arm_obj, dst_arm_obj, frame_start, frame_end):
+    """
+    Sample evaluated pose from the SOURCE armature, but write keys onto the
+    DUPLICATE armature.
+    """
+    ensure_animation_data(dst_arm_obj)
+    dst_arm_obj.animation_data.action = None
+
+    baked_action = bpy.data.actions.new(name=f"{dst_arm_obj.name}_MAYA_BAKE")
+    dst_arm_obj.animation_data.action = baked_action
+
+    depsgraph = bpy.context.evaluated_depsgraph_get()
+    baked = {}
+
+    for frame in range(frame_start, frame_end + 1):
+        scene.frame_set(frame)
+        bpy.context.view_layer.update()
+
+        src_eval = src_arm_obj.evaluated_get(depsgraph)
+        baked[frame] = {}
+
+        for src_pb in src_eval.pose.bones:
+            mat_pose = src_pb.matrix.copy()
+
+            parent = src_pb.parent
+            if parent:
+                mat_local_pose = parent.matrix.inverted() @ mat_pose
+            else:
+                mat_local_pose = mat_pose.copy()
+
+            rest_local = src_pb.bone.matrix_local.copy()
+            if parent:
+                rest_parent = parent.bone.matrix_local.copy()
+                rest_rel = rest_parent.inverted() @ rest_local
+            else:
+                rest_rel = rest_local
+
+            mat_basis = rest_rel.inverted() @ mat_local_pose
+            loc, rot_q, scale = mat_basis.decompose()
+            baked[frame][src_pb.name] = (loc.copy(), rot_q.copy(), scale.copy())
+
+    for frame, bone_data in baked.items():
+        for bone_name, (loc, rot_q, scale) in bone_data.items():
+            dst_pb = dst_arm_obj.pose.bones.get(bone_name)
+            if dst_pb is None:
+                continue
+
+            dst_pb.rotation_mode = 'XYZ'
+            dst_pb.location = loc
+            dst_pb.rotation_euler = rot_q.to_euler('XYZ')
+            dst_pb.scale = scale
+
+            dst_pb.keyframe_insert(data_path='location', frame=frame)
+            dst_pb.keyframe_insert(data_path='rotation_euler', frame=frame)
+            dst_pb.keyframe_insert(data_path='scale', frame=frame)
+
+    print(f"  Baked action '{baked_action.name}' with {len(baked_action.fcurves)} fcurves.")
+    return baked_action
+
+
+def copy_camera_animation(scene, src_cam, dst_cam, frame_start, frame_end):
+    clear_animation_data_recursive(dst_cam)
+    ensure_animation_data(dst_cam)
+
+    cam_action = bpy.data.actions.new(name=f"{dst_cam.name}_MAYA_BAKE")
+    dst_cam.animation_data.action = cam_action
+
+    if dst_cam.data and hasattr(dst_cam.data, "animation_data_create"):
+        dst_cam.data.animation_data_create()
+        lens_action = bpy.data.actions.new(name=f"{dst_cam.data.name}_MAYA_BAKE")
+        dst_cam.data.animation_data.action = lens_action
+
+    for frame in range(frame_start, frame_end + 1):
+        scene.frame_set(frame)
+        bpy.context.view_layer.update()
+
+        dst_cam.matrix_world = src_cam.matrix_world.copy()
+        dst_cam.keyframe_insert(data_path='location', frame=frame)
+        dst_cam.keyframe_insert(data_path='rotation_euler', frame=frame)
+        dst_cam.keyframe_insert(data_path='scale', frame=frame)
+
+        if src_cam.data and dst_cam.data:
+            if hasattr(src_cam.data, "lens") and hasattr(dst_cam.data, "lens"):
+                dst_cam.data.lens = src_cam.data.lens
+                dst_cam.data.keyframe_insert(data_path='lens', frame=frame)
+
+    print(f"  Baked duplicate camera '{dst_cam.name}'.")
+
+
+def select_only(objects):
+    bpy.ops.object.select_all(action='DESELECT')
+    for obj in objects:
+        obj.select_set(True)
+
+
+def main():
+    print_header("GVHMR → Maya Export")
+
+    scene = bpy.context.scene
+    frame_start = scene.frame_start
+    frame_end = scene.frame_end
+
+    print(f"  Scene frame range: {frame_start}–{frame_end}")
+
+    if not EXPORT_ALEMBIC and not EXPORT_FBX:
+        print("  Nothing to export. Set EXPORT_ALEMBIC and/or EXPORT_FBX to True.")
+        return
+
+    maya_dir = Path(OUTPUT_DIR)
+    maya_dir.mkdir(parents=True, exist_ok=True)
+    print(f"  Output folder: {maya_dir}")
+
+    if RESOLUTION_X and RESOLUTION_Y:
+        scene.render.resolution_x = RESOLUTION_X
+        scene.render.resolution_y = RESOLUTION_Y
+        print(f"  Resolution forced to: {RESOLUTION_X} × {RESOLUTION_Y}")
+
+    cameras, armatures, meshes = find_export_objects()
+    print(f"  Found {len(cameras)} camera(s), {len(armatures)} armature(s), {len(meshes)} mesh(es).")
+
+    if not cameras and not armatures and not meshes:
+        print("  No visible exportable objects found.")
+        return
+
+    export_objects = cameras + armatures + meshes
+
+    print("\n  Building clean duplicate export set ...")
+    temp_col, obj_map = duplicate_for_export(export_objects, TEMP_EXPORT_COLLECTION)
+
+    dup_cameras = [obj_map[o] for o in cameras if o in obj_map]
+    dup_armatures = [obj_map[o] for o in armatures if o in obj_map]
+    dup_meshes = [obj_map[o] for o in meshes if o in obj_map]
+
+    for obj in temp_col.objects:
+        clear_animation_data_recursive(obj)
+
+    baked_actions = []
+    if dup_armatures:
+        print("\n  Baking duplicate armature animation ...")
+        for src_arm in armatures:
+            dst_arm = obj_map[src_arm]
+            print(f"  Armature: '{src_arm.name}' → '{dst_arm.name}'")
+            baked_action = bake_armature_evaluated_pose(
+                scene,
+                src_arm,
+                dst_arm,
+                frame_start,
+                frame_end,
+            )
+            baked_actions.append(baked_action)
+
+    if cameras:
+        print("\n  Baking duplicate camera animation ...")
+        for src_cam in cameras:
+            dst_cam = obj_map[src_cam]
+            copy_camera_animation(scene, src_cam, dst_cam, frame_start, frame_end)
+
+    scene.frame_set(frame_start)
+    bpy.context.view_layer.update()
+
+    if EXPORT_ALEMBIC:
+        abc_path = maya_dir / f"{EXPORT_NAME}.abc"
+        print(f"\n  Exporting Alembic → {abc_path}")
+
+        select_only(list(temp_col.objects))
+        if dup_armatures:
+            bpy.context.view_layer.objects.active = dup_armatures[0]
+        elif dup_cameras:
+            bpy.context.view_layer.objects.active = dup_cameras[0]
+        elif dup_meshes:
+            bpy.context.view_layer.objects.active = dup_meshes[0]
+
+        bpy.ops.wm.alembic_export(
+            filepath=str(abc_path),
+            start=frame_start,
+            end=frame_end,
+            xsamples=1,
+            gsamples=1,
+            sh_open=0.0,
+            sh_close=1.0,
+            selected=True,
+            visible_objects_only=False,
+            flatten=False,
+            uvs=True,
+            normals=True,
+            vcolors=False,
+            orcos=False,
+            face_sets=False,
+            subdiv_schema=False,
+            apply_subdiv=False,
+            curves_as_mesh=False,
+            use_instancing=True,
+            global_scale=1.0,
+            triangulate=False,
+            quad_method='SHORTEST_DIAGONAL',
+            ngon_method='BEAUTY',
+            export_hair=False,
+            export_particles=False,
+            export_custom_properties=True,
+            as_background_job=False,
+            init_scene_frame_range=False,
+        )
+        print(f"  Alembic written: {abc_path}")
+
+    if EXPORT_FBX:
+        fbx_path = maya_dir / f"{EXPORT_NAME}.fbx"
+        print(f"\n  Exporting FBX → {fbx_path}")
+
+        export_selection = list(temp_col.objects)
+        select_only(export_selection)
+
+        if dup_armatures:
+            bpy.context.view_layer.objects.active = dup_armatures[0]
+        elif dup_cameras:
+            bpy.context.view_layer.objects.active = dup_cameras[0]
+        elif dup_meshes:
+            bpy.context.view_layer.objects.active = dup_meshes[0]
+
+        bpy.ops.export_scene.fbx(
+            filepath=str(fbx_path),
+            use_selection=True,
+            use_visible=False,
+
+            global_scale=1.0,
+            apply_unit_scale=True,
+            apply_scale_options='FBX_SCALE_NONE',
+
+            use_space_transform=True,
+            bake_space_transform=False,
+
+            object_types={'ARMATURE', 'CAMERA', 'MESH'},
+            use_mesh_modifiers=True,
+            use_armature_deform_only=True,
+            add_leaf_bones=False,
+
+            primary_bone_axis='Y',
+            secondary_bone_axis='X',
+            armature_nodetype='ROOT',
+
+            bake_anim=True,
+            bake_anim_use_all_bones=True,
+            bake_anim_use_nla_strips=False,
+            bake_anim_use_all_actions=False,
+            bake_anim_force_startend_keying=True,
+            bake_anim_step=1.0,
+            bake_anim_simplify_factor=0.0,
+
+            path_mode='AUTO',
+            embed_textures=False,
+            batch_mode='OFF',
+            axis_forward='-Z',
+            axis_up='Y',
+        )
+
+        print(f"  FBX written: {fbx_path}")
+
+    res_x = scene.render.resolution_x
+    res_y = scene.render.resolution_y
+    fps = scene.render.fps / scene.render.fps_base
+
+    print("\nDone!")
+    print(f"  Render resolution : {res_x} × {res_y}")
+    print(f"  Frame range       : {frame_start} – {frame_end} @ {fps:.6g} fps")
+    print("  Maya import tips:")
+    print("    • Use a new empty scene")
+    print("    • File > Import > choose FBX")
+    print("    • Preset: Autodesk Media and Entertainment")
+    print("    • Make sure Animation / Deformed Models / Skins are enabled")
+    print("    • Check whether joints have keys in Maya if animation still appears static")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/blender_import_gvhmr.py
+++ b/scripts/blender_import_gvhmr.py
@@ -59,24 +59,24 @@ import os
 # ── CONFIGURE ────────────────────────────────────────────────────────────────
 
 # Path to the main NPZ from "GVHMR Inference" (always required)
-NPZ_PATH = ""
+NPZ_PATH = "/mnt/share/dev-lbringer/ComfyUI_nightly/output/smpl_params_0014.npz"
 
 # Path to the separate camera NPZ from "GVHMR Inference"
 # (produced only when moving_camera=True; leave empty "" to load camera data
 #  from the main NPZ if it was embedded there)
-CAMERA_NPZ_PATH = ""
+CAMERA_NPZ_PATH = "/mnt/share/dev-lbringer/ComfyUI_nightly/output/camera_trajectory_0009.npz"
 
 # Path to the SMPC .bin file from "SMPL Viewer with Camera" node.
 # When set, uses the Procrustes-REFINED camera (same as what the viewer shows)
 # instead of the raw NPZ camera — fixes height and alignment offsets.
 # Takes priority over CAMERA_NPZ_PATH when provided.
-SMPC_BIN_PATH = ""
+SMPC_BIN_PATH = "/mnt/share/dev-lbringer/ComfyUI_nightly/output/smpl_camera_mesh_0013.bin"
 
 # Path to the BVH from "SMPL to BVH Converter" node.
 # Imports as a native Blender armature — fully editable in Pose Mode / NLA editor.
 # Can be used alongside GLB_PATH (the GLB provides the skin mesh, the BVH the rig).
 # Set to "" to skip.
-BVH_PATH = ""
+BVH_PATH = ""  # disabled — using the GLB's built-in armature instead
 
 # Path to the animated FBX from "BVH to FBX Retargeter" node.
 # This is a fully rigged character with baked SMPL motion — editable in Blender.
@@ -85,10 +85,10 @@ FBX_PATH = ""
 
 # Path to the GLB from "SMPL to GLB Animation" node (simpler, no rig).
 # Used only when FBX_PATH is empty. Set to "" to skip body import entirely.
-GLB_PATH = ""
+GLB_PATH = "/mnt/share/dev-lbringer/ComfyUI_nightly/output/smpl_anim_0009.glb"
 
 # Frames-per-second of the original video fed to GVHMR Inference.
-FPS = 30
+FPS = 24
 
 # Sensor width used to convert pixel focal length → mm (Blender default: 36 mm).
 SENSOR_WIDTH_MM = 36.0
@@ -102,7 +102,7 @@ FLIP_CAMERA_Y = True
 # the BVH root is at (transl), so the armature needs to be shifted up by J[0].y
 # (which becomes a Z offset after Y-up → Z-up conversion).
 # Set to "" to disable auto-computation and use BVH_Z_OFFSET manually instead.
-SMPLX_MODEL_PATH = ""
+SMPLX_MODEL_PATH = "/mnt/share/dev-lbringer/ComfyUI_nightly/models/motion_capture/body_models/smplx/SMPLX_NEUTRAL.npz"
 
 # Manual Z offset applied to the BVH armature (in Blender units = metres).
 # Ignored when SMPLX_MODEL_PATH is set and the file is found.

--- a/scripts/blender_import_gvhmr.py
+++ b/scripts/blender_import_gvhmr.py
@@ -1,0 +1,458 @@
+"""
+GVHMR → Blender Import Script
+==============================
+Imports a rigged + animated FBX character and animated camera poses produced
+by the ComfyUI-MotionCapture pipeline into the current Blender scene.
+
+Usage
+-----
+1. Edit the CONFIGURE section below with your file paths and FPS.
+2. Open Blender's Scripting workspace.
+3. Paste / open this file, then click "Run Script".
+
+What this script does
+---------------------
+- Optionally imports the animated FBX (rigged character retargeted with SMPL
+  motion) produced by the "BVH to FBX Retargeter" node.
+- Creates a Blender Camera object animated with the predicted camera trajectory
+  (position, rotation, and focal length keyframed per frame).
+- Sets the scene frame range and FPS to match the captured clip.
+
+Workflow in ComfyUI
+-------------------
+1. GVHMR Inference        →  npz_path  +  camera_npz_path
+2. SMPL to BVH Converter  →  bvh_data           (takes npz_path as input)
+3. BVH to FBX Retargeter  →  output_path (.fbx)  (takes bvh_data + your
+                                                   rigged character FBX/VRM)
+4. Run this script in Blender pointing at the .fbx and the two .npz files.
+
+Note on SMPLToFBX
+-----------------
+The "SMPL to FBX Retargeting" node exists in the repo but requires a
+SMPL_PARAMS input that no node currently outputs — it is not wirable in the
+ComfyUI graph yet.  Use the BVH route above instead.
+
+Coordinate conventions
+----------------------
+GVHMR world frame  : Y-up, gravity-aligned (same as SMPL convention).
+GVHMR camera frame : OpenGL-style (-Z forward, Y up) — this is because
+                     R_cam2world is derived from SMPL body rotations that live
+                     in the same Y-up space.
+Blender world      : Z-up.
+Blender camera     : -Z forward, Y up  (identical to GVHMR camera frame).
+
+Therefore the only conversion needed is world Y-up → Z-up, applied uniformly
+to all positions and rotation matrices.  The camera-local axes need no flip.
+
+If the imported camera appears to face the wrong direction, try toggling the
+FLIP_CAMERA_Y boolean in the CONFIGURE section — this adds a 180° X-axis
+rotation that swaps between OpenGL and OpenCV camera conventions.
+"""
+
+import bpy
+import numpy as np
+from mathutils import Matrix, Vector, Euler
+import math
+import os
+
+
+# ── CONFIGURE ────────────────────────────────────────────────────────────────
+
+# Path to the main NPZ from "GVHMR Inference" (always required)
+NPZ_PATH = ""
+
+# Path to the separate camera NPZ from "GVHMR Inference"
+# (produced only when moving_camera=True; leave empty "" to load camera data
+#  from the main NPZ if it was embedded there)
+CAMERA_NPZ_PATH = ""
+
+# Path to the SMPC .bin file from "SMPL Viewer with Camera" node.
+# When set, uses the Procrustes-REFINED camera (same as what the viewer shows)
+# instead of the raw NPZ camera — fixes height and alignment offsets.
+# Takes priority over CAMERA_NPZ_PATH when provided.
+SMPC_BIN_PATH = ""
+
+# Path to the BVH from "SMPL to BVH Converter" node.
+# Imports as a native Blender armature — fully editable in Pose Mode / NLA editor.
+# Can be used alongside GLB_PATH (the GLB provides the skin mesh, the BVH the rig).
+# Set to "" to skip.
+BVH_PATH = ""
+
+# Path to the animated FBX from "BVH to FBX Retargeter" node.
+# This is a fully rigged character with baked SMPL motion — editable in Blender.
+# Set to "" to skip or use GLB_PATH instead.
+FBX_PATH = ""
+
+# Path to the GLB from "SMPL to GLB Animation" node (simpler, no rig).
+# Used only when FBX_PATH is empty. Set to "" to skip body import entirely.
+GLB_PATH = ""
+
+# Frames-per-second of the original video fed to GVHMR Inference.
+FPS = 30
+
+# Sensor width used to convert pixel focal length → mm (Blender default: 36 mm).
+SENSOR_WIDTH_MM = 36.0
+
+# Set to True if the imported camera faces the wrong direction.
+# Adds a 180° rotation around X (OpenCV ↔ OpenGL camera convention swap).
+FLIP_CAMERA_Y = True
+
+# Path to SMPLX_NEUTRAL.npz — used to auto-compute the Z offset needed to align
+# the BVH armature with the GLB mesh.  The GLB root is at (transl + J[0]) while
+# the BVH root is at (transl), so the armature needs to be shifted up by J[0].y
+# (which becomes a Z offset after Y-up → Z-up conversion).
+# Set to "" to disable auto-computation and use BVH_Z_OFFSET manually instead.
+SMPLX_MODEL_PATH = ""
+
+# Manual Z offset applied to the BVH armature (in Blender units = metres).
+# Ignored when SMPLX_MODEL_PATH is set and the file is found.
+# Set this if auto-computation is unavailable and the rig floats above the mesh.
+BVH_Z_OFFSET = 0.0
+
+# ── END CONFIGURE ─────────────────────────────────────────────────────────────
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _compute_bvh_z_offset(npz_path, smplx_model_path):
+    """
+    Compute the Z offset to apply to the BVH armature so it aligns with the GLB.
+
+    The GLB root node is animated at (transl + J[0]) while the BVH root is at
+    (transl).  After Y-up → Z-up conversion both J[0].y and transl.y map to Z,
+    so the BVH armature needs to be shifted by +J[0].y to match the GLB.
+    """
+    data = np.load(smplx_model_path, allow_pickle=True)
+    v_template = data['v_template'].astype(np.float64)                 # (V, 3)
+    shapedirs  = data['shapedirs'][:, :, :10].astype(np.float64)       # (V, 3, 10)
+    J_reg = data['J_regressor']
+    if isinstance(J_reg, np.ndarray) and J_reg.ndim == 0:
+        J_reg = J_reg.item()
+    if hasattr(J_reg, 'toarray'):
+        J_reg = J_reg.toarray()
+    J_reg = np.asarray(J_reg, dtype=np.float64)
+
+    # Use subject's betas if available, else neutral
+    betas = np.zeros(10, dtype=np.float64)
+    try:
+        subj = np.load(npz_path)
+        if 'betas' in subj:
+            b = subj['betas']
+            if b.ndim == 2:
+                b = b[0]
+            betas = b[:10].astype(np.float64)
+    except Exception:
+        pass
+
+    v_shaped = v_template + np.einsum('vck,k->vc', shapedirs, betas)
+    J0 = (J_reg @ v_shaped)[0]   # pelvis in Y-up SMPL template space
+    # J0[1] is the Y component; after Y→Z conversion this becomes Blender Z
+    return float(J0[1])
+
+
+def _load_camera_from_smpc_bin(bin_path):
+    """
+    Parse the SMPC .bin file written by 'SMPL Viewer with Camera' and extract
+    the Procrustes-refined R_cam2world, t_cam2world, K_fullimg, img dimensions,
+    and fps.  Returns (R, t, K, img_w, img_h, fps) or raises on failure.
+
+    Binary layout (matches smpl_camera_viewer_node.py):
+      "SMPC"           4 bytes  magic
+      num_frames       uint32
+      num_vertices     uint32
+      num_faces        uint32
+      fps              float32
+      mesh_color       64 bytes (null-padded UTF-8)
+      has_camera       uint32
+      img_width        uint32
+      img_height       uint32
+      vertex_data      F * V * 3 * float32
+      face_data        num_faces * 3 * uint32
+      [if has_camera]
+        R_cam2world    F * 3 * 3 * float32
+        t_cam2world    F * 3 * float32
+        K_fullimg      F * 3 * 3 * float32
+    """
+    import struct
+    with open(bin_path, "rb") as f:
+        magic = f.read(4)
+        if magic != b"SMPC":
+            raise ValueError(f"Not an SMPC file: {bin_path}")
+        num_frames  = struct.unpack("<I", f.read(4))[0]
+        num_verts   = struct.unpack("<I", f.read(4))[0]
+        num_faces   = struct.unpack("<I", f.read(4))[0]
+        fps         = struct.unpack("<f", f.read(4))[0]
+        f.read(64)                                           # mesh_color
+        has_camera  = struct.unpack("<I", f.read(4))[0]
+        img_w       = struct.unpack("<I", f.read(4))[0]
+        img_h       = struct.unpack("<I", f.read(4))[0]
+        # skip vertex data + face data
+        f.read(num_frames * num_verts * 3 * 4)
+        f.read(num_faces * 3 * 4)
+        if not has_camera:
+            return None, None, None, img_w, img_h, fps
+        R = np.frombuffer(f.read(num_frames * 9 * 4),  dtype=np.float32).reshape(num_frames, 3, 3).astype(np.float64)
+        t = np.frombuffer(f.read(num_frames * 3 * 4),  dtype=np.float32).reshape(num_frames, 3).astype(np.float64)
+        K = np.frombuffer(f.read(num_frames * 9 * 4),  dtype=np.float32).reshape(num_frames, 3, 3).astype(np.float64)
+    print(f"  Loaded Procrustes-refined camera from SMPC bin ({num_frames} frames, fps={fps})")
+    return R, t, K, img_w, img_h, fps
+
+# Rotation matrix: world Y-up (GVHMR) → world Z-up (Blender)
+#   Blender X = GVHMR X
+#   Blender Y = -GVHMR Z
+#   Blender Z =  GVHMR Y
+R_Y2Z = np.array([
+    [1,  0,  0],
+    [0,  0, -1],
+    [0,  1,  0],
+], dtype=np.float64)
+
+# Optional camera convention flip (180° around X)
+R_FLIP = np.array([
+    [1,  0,  0],
+    [0, -1,  0],
+    [0,  0, -1],
+], dtype=np.float64)
+
+
+def _load_camera_data(npz_path, camera_npz_path):
+    """Load R_cam2world, t_cam2world, K_fullimg, img_width, img_height."""
+    R, t, K, img_w, img_h = None, None, None, 1920, 1080
+
+    def _try_extract(src):
+        nonlocal img_w, img_h
+        if 'R_cam2world' in src and 't_cam2world' in src and 'K_fullimg' in src:
+            r = src['R_cam2world'].astype(np.float64)
+            _t = src['t_cam2world'].astype(np.float64)
+            k = src['K_fullimg'].astype(np.float64)
+            if 'img_width' in src:
+                img_w = int(src['img_width'].flat[0])
+            if 'img_height' in src:
+                img_h = int(src['img_height'].flat[0])
+            return r, _t, k
+        elif 'R_w2c' in src and 't_w2c' in src and 'K_fullimg' in src:
+            # Old format: world-to-cam → cam-to-world
+            R_w2c = src['R_w2c'].astype(np.float64)
+            t_w2c = src['t_w2c'].astype(np.float64)
+            r = R_w2c.transpose(0, 2, 1)
+            _t = -np.einsum('fij,fj->fi', r, t_w2c)
+            k = src['K_fullimg'].astype(np.float64)
+            if 'img_width' in src:
+                img_w = int(src['img_width'].flat[0])
+            if 'img_height' in src:
+                img_h = int(src['img_height'].flat[0])
+            print("  [warning] Using old R_w2c/t_w2c format — re-run GVHMR for best results.")
+            return r, _t, k
+        return None, None, None
+
+    # 1. Try separate camera NPZ first
+    if camera_npz_path and os.path.isfile(camera_npz_path):
+        cam_data = np.load(camera_npz_path)
+        R, t, K = _try_extract(cam_data)
+        if R is not None:
+            print(f"  Loaded camera data from: {camera_npz_path}")
+
+    # 2. Fall back to main NPZ
+    if R is None and os.path.isfile(npz_path):
+        main_data = np.load(npz_path)
+        R, t, K = _try_extract(main_data)
+        if R is not None:
+            print(f"  Loaded camera data embedded in: {npz_path}")
+
+    if R is None:
+        print("  [warning] No camera trajectory found — camera object will not be animated.")
+
+    return R, t, K, img_w, img_h
+
+
+def _apply_world_conversion(R_c2w, t_c2w):
+    """Convert all camera matrices from GVHMR Y-up to Blender Z-up."""
+    F = R_c2w.shape[0]
+    R_out = np.zeros_like(R_c2w)
+    t_out = np.zeros_like(t_c2w)
+    cam_flip = R_FLIP if FLIP_CAMERA_Y else np.eye(3)
+    for f in range(F):
+        # Convert rotation: R_blender = R_y2z @ R_c2w @ cam_flip
+        R_out[f] = R_Y2Z @ R_c2w[f] @ cam_flip
+        # Convert translation: t_blender = R_y2z @ t_c2w
+        t_out[f] = R_Y2Z @ t_c2w[f]
+    return R_out, t_out
+
+
+def _rotation_matrix_to_blender_matrix(R, t):
+    """Build a 4×4 Blender Matrix from a 3×3 numpy rotation and 3-vector translation."""
+    mat = Matrix([
+        [R[0, 0], R[0, 1], R[0, 2], t[0]],
+        [R[1, 0], R[1, 1], R[1, 2], t[1]],
+        [R[2, 0], R[2, 1], R[2, 2], t[2]],
+        [0,       0,       0,       1   ],
+    ])
+    return mat
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    print("\n=== GVHMR → Blender Import ===")
+
+    # -- Validate paths -------------------------------------------------------
+    global NPZ_PATH
+    if NPZ_PATH and not os.path.isfile(NPZ_PATH):
+        print(f"  [warning] NPZ not found (will be skipped): {NPZ_PATH}")
+        NPZ_PATH = ""
+
+    # -- Load camera data -----------------------------------------------------
+    print("[1/4] Loading camera data …")
+    bin_fps = None
+    if SMPC_BIN_PATH and os.path.isfile(SMPC_BIN_PATH):
+        R_c2w, t_c2w, K, img_w, img_h, bin_fps = _load_camera_from_smpc_bin(SMPC_BIN_PATH)
+    elif SMPC_BIN_PATH:
+        print(f"  [warning] SMPC bin not found, falling back to NPZ: {SMPC_BIN_PATH}")
+        R_c2w, t_c2w, K, img_w, img_h = _load_camera_data(NPZ_PATH, CAMERA_NPZ_PATH)
+    else:
+        R_c2w, t_c2w, K, img_w, img_h = _load_camera_data(NPZ_PATH, CAMERA_NPZ_PATH)
+
+    num_frames = R_c2w.shape[0] if R_c2w is not None else None
+
+    # -- Configure scene ------------------------------------------------------
+    print("[2/4] Configuring scene …")
+    scene = bpy.context.scene
+    effective_fps = bin_fps if (bin_fps and bin_fps > 0) else FPS
+    scene.render.fps = int(round(effective_fps))
+    scene.render.fps_base = scene.render.fps / effective_fps  # handles non-integer FPS
+    if num_frames is not None:
+        scene.frame_start = 1
+        scene.frame_end = num_frames
+    scene.render.resolution_x = img_w
+    scene.render.resolution_y = img_h
+    print(f"  Scene: {num_frames} frames @ {effective_fps} fps, {img_w}×{img_h}")
+
+    # -- Import body (FBX or GLB) ---------------------------------------------
+    print("[3/4] Importing body …")
+    if FBX_PATH and os.path.isfile(FBX_PATH):
+        bpy.ops.import_scene.fbx(filepath=FBX_PATH, automatic_bone_orientation=True)
+        print(f"  Imported FBX: {FBX_PATH}")
+    elif FBX_PATH:
+        print(f"  [warning] FBX not found, skipping: {FBX_PATH}")
+    elif GLB_PATH and os.path.isfile(GLB_PATH):
+        before_import = set(bpy.data.objects.keys())
+        bpy.ops.import_scene.gltf(filepath=GLB_PATH)
+        print(f"  Imported GLB: {GLB_PATH}")
+
+        # Clear custom bone shapes (icospheres) assigned by the GLTF importer
+        # and switch to STICK display — no bone positions are touched.
+        new_objs = [bpy.data.objects[n] for n in bpy.data.objects.keys() if n not in before_import]
+        glb_armatures = [o for o in new_objs if o.type == 'ARMATURE']
+        for arm in glb_armatures:
+            arm.data.display_type = 'OCTAHEDRAL'
+            for pb in arm.pose.bones:
+                pb.custom_shape = None
+            print(f"  Set STICK display on armature: {arm.name}")
+    elif GLB_PATH:
+        print(f"  [warning] GLB not found, skipping: {GLB_PATH}")
+    else:
+        print("  No body path set — skipping body import.")
+
+    # -- Import BVH armature --------------------------------------------------
+    if BVH_PATH and os.path.isfile(BVH_PATH):
+        # Track objects before import so we can find the new armature
+        before = set(bpy.data.objects.keys())
+        bpy.ops.import_anim.bvh(
+            filepath=BVH_PATH,
+            use_fps_scale=False,   # keep rotations as-is, don't rescale to scene FPS
+            update_scene_fps=False,
+            update_scene_duration=False,
+        )
+        new_objs = [bpy.data.objects[n] for n in bpy.data.objects.keys() if n not in before]
+        bvh_armatures = [o for o in new_objs if o.type == 'ARMATURE']
+
+        # Compute and apply Z offset to align BVH root with GLB root
+        z_offset = BVH_Z_OFFSET
+        if SMPLX_MODEL_PATH and os.path.isfile(SMPLX_MODEL_PATH):
+            try:
+                z_offset = _compute_bvh_z_offset(NPZ_PATH, SMPLX_MODEL_PATH)
+                print(f"  BVH Z offset (auto from J[0]): {z_offset:.4f} m")
+            except Exception as e:
+                print(f"  [warning] Could not auto-compute BVH Z offset: {e} — using BVH_Z_OFFSET={BVH_Z_OFFSET}")
+        elif BVH_Z_OFFSET != 0.0:
+            print(f"  BVH Z offset (manual): {z_offset:.4f} m")
+
+        for arm in bvh_armatures:
+            arm.location.z += z_offset
+
+        print(f"  Imported BVH armature: {BVH_PATH}")
+    elif BVH_PATH:
+        print(f"  [warning] BVH not found, skipping: {BVH_PATH}")
+
+    # -- Create / reuse camera ------------------------------------------------
+    print("[4/4] Building animated camera …")
+
+    base_name = "GVHMR_Camera"
+    idx = 1
+    CAM_NAME = base_name
+    while CAM_NAME in bpy.data.objects:
+        CAM_NAME = f"{base_name}.{idx:03d}"
+        idx += 1
+
+    cam_data = bpy.data.cameras.new(name=CAM_NAME)
+    cam_data.sensor_width = SENSOR_WIDTH_MM
+    cam_obj = bpy.data.objects.new(CAM_NAME, cam_data)
+    scene.collection.objects.link(cam_obj)
+
+    # Make it the active scene camera
+    scene.camera = cam_obj
+
+    if R_c2w is not None:
+        R_bl, t_bl = _apply_world_conversion(R_c2w, t_c2w)
+
+        for f in range(num_frames):
+            frame_idx = f + 1  # Blender frames are 1-based
+
+            # Camera world matrix
+            mat = _rotation_matrix_to_blender_matrix(R_bl[f], t_bl[f])
+            cam_obj.matrix_world = mat
+
+            # Keyframe location and rotation
+            cam_obj.keyframe_insert(data_path="location", frame=frame_idx)
+            cam_obj.keyframe_insert(data_path="rotation_euler", frame=frame_idx)
+
+            # Focal length from intrinsics (K[f][0,0] = fx in pixels)
+            if K is not None:
+                fx = float(K[f][0, 0])
+                focal_mm = fx * SENSOR_WIDTH_MM / img_w
+                cam_data.lens = focal_mm
+                cam_data.keyframe_insert(data_path="lens", frame=frame_idx)
+
+        # Set interpolation to LINEAR for all camera fcurves (avoids overshoots)
+        if cam_obj.animation_data and cam_obj.animation_data.action:
+            for fc in cam_obj.animation_data.action.fcurves:
+                for kp in fc.keyframe_points:
+                    kp.interpolation = 'LINEAR'
+        if cam_data.animation_data and cam_data.animation_data.action:
+            for fc in cam_data.animation_data.action.fcurves:
+                for kp in fc.keyframe_points:
+                    kp.interpolation = 'LINEAR'
+
+        print(f"  Camera '{CAM_NAME}' animated over {num_frames} frames.")
+        print(f"  Camera position frame 1: {tuple(round(v, 3) for v in t_bl[0])}")
+        if K is not None:
+            fx0 = float(K[0][0, 0])
+            print(f"  Focal length frame 1: {fx0 * SENSOR_WIDTH_MM / img_w:.1f} mm  (fx={fx0:.1f} px)")
+    else:
+        print(f"  Camera '{CAM_NAME}' created (no animation — no camera data found).")
+
+    # Jump to frame 1
+    scene.frame_set(1)
+
+    print("\nDone! Tips:")
+    print("  • Press Numpad-0 to look through the GVHMR_Camera.")
+    print("  • Press Space to play back the animation.")
+    if FLIP_CAMERA_Y is False:
+        print("  • If the camera faces the wrong direction, set FLIP_CAMERA_Y = True and re-run.")
+
+
+main()


### PR DESCRIPTION

<img width="535" height="422" alt="comfy_node_mocap" src="https://github.com/user-attachments/assets/87fa0d71-93ef-4254-b22a-01ea97121932" />

![GVHMR](https://github.com/user-attachments/assets/4ee6d57f-e23f-4bbb-b7d7-e4efe698dd00)

- Add gender input (neutral / male / female) to select SMPLX body model
- Add skeleton input: smplx_55 (full rig with fingers) or smpl_22 (body only)
- Add hand_pose input: halfway (model mean, natural relaxed), open, or closed Applies only to smplx_55; uses hands_meanl/r from the SMPLX model for the halfway pose so it matches what SMPL Viewer with Camera displays

nodes/bvh_retarget_node.py:
- Fix NameError: Log.info -> log.info (line 432)

nodes/inference_node.py:
- Fix DPVO integration: pass torch CUDA tensor instead of numpy array for frames, and pre-allocate intrinsics tensor outside the loop

scripts/blender_import_gvhmr.py:
- New script for importing GVHMR pipeline outputs into Blender
- Imports animated GLB (skinned mesh + skeleton) or FBX / BVH armature
- Creates an animated camera from SMPC .bin (Procrustes-refined) or raw camera NPZ, with per-frame focal length keyframing
- Handles GVHMR Y-up -> Blender Z-up coordinate conversion
- Supports re-running the script to add additional cameras without overwriting existing ones